### PR TITLE
Support for swapping Y and Z axis

### DIFF
--- a/examples/load_vox.rs
+++ b/examples/load_vox.rs
@@ -5,7 +5,7 @@ fn main() {
     App::new()
         .insert_resource(Msaa { samples: 4 })
         .add_plugins(DefaultPlugins)
-        .add_plugin(VoxPlugin)
+        .add_plugin(VoxPlugin::default())
         .add_startup_system(setup.system())
         .run();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,10 +6,15 @@ use bevy_asset::AddAsset;
 
 /// Adds support for Vox file loading to Apps
 #[derive(Default)]
-pub struct VoxPlugin;
+pub struct VoxPlugin {
+    /// MagicaVoxel considers Z as the vertical dimension. Setting this to true will use Y as height
+    pub swap_yz: bool,
+}
 
 impl Plugin for VoxPlugin {
     fn build(&self, app: &mut App) {
-        app.init_asset_loader::<VoxLoader>();
+        app.add_asset_loader(VoxLoader {
+            swap_yz: self.swap_yz,
+        });
     }
 }


### PR DESCRIPTION
MagicaVoxel considers the Y axis to represent height. Most 3D environments (Bevy included), use Z to represent height. This introduces a config value to the plugin to automatically swap Y and Z.