### PR TITLE
chore: upgrade `bevy` to `0.13`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ name = "load_vox"
 path = "examples/load_vox.rs"
 
 [dependencies]
-bevy = { version = "0.12", default-features = false, features = ["bevy_asset", "bevy_scene","bevy_pbr"] }
+bevy = { version = "0.13", default-features = false, features = ["bevy_asset", "bevy_scene","bevy_pbr"] }
 anyhow = "1"
 thiserror = "1"
 dot_vox = "4.1"
 
 [dev-dependencies]
-bevy = { version = "0.12" }
+bevy = { version = "0.13" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_vox"
-version = "0.8.1"
+version = "0.9.0"
 authors = ["erasin <erasinoo@gmail.com>"]
 edition = "2021"
 description = "Load MagicaVoxel Vox file for bevy engine "

--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ use bevy_vox::VoxPlugin;
 
 fn main() {
     App::new()
-        .insert_resource(Msaa { samples: 4 })
+        .insert_resource(Msaa::Sample4)
         .add_plugins(DefaultPlugins)
+        .add_plugins(VoxPlugin::default())
         .insert_resource(AmbientLight {
             color: Color::WHITE,
             brightness: 0.5,
         })
-        .add_plugin(VoxPlugin::default())
-        .add_startup_system(setup)
+        .add_systems(Startup, setup)
         .run();
 }
 
@@ -39,7 +39,11 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     // light
     commands.spawn(PointLightBundle {
-        transform: Transform::from_xyz(3.0, 1.2, 2.5),
+        point_light: PointLight {
+            intensity: 3_000_000.0,
+            ..Default::default()
+        },
+        transform: Transform::from_xyz(3.0, -3.5, 4.5),
         ..Default::default()
     });
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ Load MagicaVoxel Vox file for [bevy](https://github.com/bevyengine/bevy/) engine
 
 | bevy_vox | bevy  |
 | -------- | ----- |
+| 0.9      | 0.13  |
 | 0.8      | 0.12  |
 | 0.7      | 0.10  |
 | 0.6      | 0.9   |

--- a/examples/load_vox.rs
+++ b/examples/load_vox.rs
@@ -24,7 +24,11 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     // light
     commands.spawn(PointLightBundle {
-        transform: Transform::from_xyz(3.0, 1.2, 2.5),
+        point_light: PointLight {
+            intensity: 3_000_000.0,
+            ..Default::default()
+        },
+        transform: Transform::from_xyz(3.0, -3.5, 4.5),
         ..Default::default()
     });
 

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -3,8 +3,8 @@ use anyhow::Result;
 use bevy::{
     asset::{io::Reader, AssetLoader, AsyncReadExt, LoadContext},
     prelude::{
-        shape::Cube, BuildWorldChildren, Color, Mesh, PbrBundle, SpatialBundle, StandardMaterial,
-        Transform, World,
+        BuildWorldChildren, Color, Cuboid, Mesh, PbrBundle, SpatialBundle, StandardMaterial,
+        Transform, Vec3, World,
     },
     scene::Scene,
     utils::BoxedFuture,
@@ -62,7 +62,7 @@ async fn load_vox<'a, 'b>(
         }
     };
 
-    let size = 1.0;
+    let size = Vec3::splat(1.0);
 
     let mut colors: Vec<usize> = Vec::new();
     data.models.iter().for_each(|model| {
@@ -89,7 +89,7 @@ async fn load_vox<'a, 'b>(
         }
     }
 
-    load_context.add_labeled_asset("cube".to_owned(), Mesh::from(Cube { size }));
+    load_context.add_labeled_asset("cube".to_owned(), Mesh::from(Cuboid::from_size(size)));
 
     let mut world = World::default();
     for model in data.models.iter() {


### PR DESCRIPTION
### Changes

- upgrade `bevy` from `0.12` to `0.13`
- fix deprecated struct `Cube` with `Cuboid`
- fix `light` in `load_vox` example
- edit `Example` section in README
- bump project to `0.9.0`
